### PR TITLE
Fix drowning issues

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -661,6 +661,7 @@ savelife(how)
 int how;
 {
 	u.uswldtim = 0;
+	u.divetimer = ACURR(A_CON)/3;
 	u.uhp = u.uhpmax;
 	if (YouHunger < 500) {
 		if(Race_if(PM_INCANTIFIER)) u.uen = u.uenmax/4;

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -67,9 +67,9 @@ unsigned gpflags;
 			if(mtmp == &youmonst && level.flags.lethe)
 				return FALSE;
 			if (mtmp == &youmonst)
-				return !!(Amphibious);
+				return !!(Breathless);	/* not Amphibious -- teleporting into 3Dwater with limited breath can be very dangerous */
 			else return (mon_resistance(mtmp,SWIMMING) || breathless_mon(mtmp) || amphibious_mon(mtmp));
-	    } else if (is_pool(x,y, FALSE) && !(ignorewater || (mtmp == &youmonst && Is_waterlevel(&u.uz)))) {
+	    } else if (is_pool(x,y, FALSE) && !ignorewater) {
 			if(mtmp == &youmonst && level.flags.lethe)
 				return !!(Levitation || Flying || Wwalking);
 			if (mtmp == &youmonst)

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -655,7 +655,10 @@ nh_timeout()
 
 	if(u.divetimer<=0){
 		You("can't hold your breath any longer.");
-		if((!Swimming && !Amphibious && is_pool(u.ux,u.uy, FALSE)) || is_3dwater(u.ux,u.uy)) drown();
+		if((!Swimming && !Amphibious && is_pool(u.ux,u.uy, FALSE)) || is_3dwater(u.ux,u.uy)) {
+			u.dx = u.dy = 0;
+			drown();
+		}
 		u.usubwater = 0;
 		vision_full_recalc = 1;
 		vision_recalc(2);	/* unsee old position */

--- a/src/trap.c
+++ b/src/trap.c
@@ -3444,7 +3444,7 @@ drown()
 		else return(FALSE);
 	}
 	
-	if (!u.uinwater) {
+	if (!u.uinwater || (!is_3dwater(u.ux-u.dx,u.uy-u.dy) && is_3dwater(u.ux,u.uy))) {
 	    You("%s into the %swater%c",
 		Is_waterlevel(&u.uz) ? "plunge" : Flying ? "fly" : Levitation ? "hover" : "fall",
 		sparkle,
@@ -3490,7 +3490,7 @@ drown()
 		} else if(Amphibious && !Swimming){
 			u.usubwater = 1;
 		}
-		if (Amphibious &&  u.usubwater){
+		if (u.usubwater) {
 			if (flags.verbose)
 				if(!Swimming) pline("But you aren't drowning.");
 			if (!Is_waterlevel(&u.uz)) {
@@ -3566,7 +3566,12 @@ drown()
 			You("dump some of your gear to lose weight...");
 		if (succ) {
 			pline("Pheew!  That was close.");
-			u.usubwater = 0;
+			if (u.usubwater) {
+				u.usubwater = 0;
+				vision_recalc(2);
+				vision_full_recalc = 1;
+				doredraw();
+			}
 			teleds(x,y,TRUE);
 			return(TRUE);
 		}
@@ -3574,7 +3579,17 @@ drown()
 		pline("But in vain.");
 	}
 	u.uinwater = 1;
-	u.usubwater = 1;
+	if (!u.usubwater) {
+		u.usubwater = 1;
+		vision_recalc(2);
+		vision_full_recalc = 1;
+		doredraw();
+	}
+	if (u.divetimer > 0) {
+		u.divetimer--;
+		return FALSE;
+	}
+
 	You("drown.");
 	/* [ALI] Vampires return to vampiric form on drowning.
 	 */


### PR DESCRIPTION
Before instant death, drowning first uses up your breath meter. This puts you underwater as though you were amphibious. Moving next to a crawl-able escape instantly and immediately brings you to shore (as before). This may need to be adjusted in the future for balance / verisimilatude.

Teleports do not consider 3D-water to be safe if you can only survive in it by holding your breath.

Fixes infinite drowning-loop on the plane of water.